### PR TITLE
Include lbound and ubound of intercept estimate

### DIFF
--- a/R/zyp.R
+++ b/R/zyp.R
@@ -133,8 +133,8 @@ zyp.zhang <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.
 
   ret <- c(lbound = as.numeric(ci[2, 1]), trend=as.numeric(trend), trendp=(as.numeric(trend) * n), ubound = as.numeric(ci[2, 2]),
            tau=as.numeric(tau), sig=as.numeric(Bsig), nruns=as.numeric(k), autocor=as.numeric(c0), valid_frac=as.numeric(length(dmap)/length(y)),
-           linear=as.numeric(lm(data~t)$coefficients[2]), lbound_intercept=as.numeric(ci[1,1]), intercept=as.numeric(sen$coefficients[1]),
-           ubound_intercept=as.numeric(ci[1,2]))
+           linear=as.numeric(lm(data~t)$coefficients[2]), intercept=as.numeric(sen$coefficients[1]),
+           lbound_intercept=as.numeric(ci[1,1]), ubound_intercept=as.numeric(ci[1,2]))
   return(ret)
 }
 
@@ -199,8 +199,8 @@ zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.f
 
   ret <- c(lbound = as.numeric(ci[2, 1]), trend=as.numeric(trend), trendp=as.numeric(trend) * n, ubound = as.numeric(ci[2, 2]),
            tau=as.numeric(tau), sig=as.numeric(Bsig), nruns=1, autocor=as.numeric(ac), valid_frac=as.numeric(length(dmap)/length(y)),
-           linear=as.numeric(lm(dat~t)$coefficients[2]), lbound_intercept=as.numeric(ci[1,1]), intercept=as.numeric(sen$coefficients[1]),
-           ubound_intercept=as.numeric(ci[1,2]))
+           linear=as.numeric(lm(dat~t)$coefficients[2]), intercept=as.numeric(sen$coefficients[1]),
+           lbound_intercept=as.numeric(ci[1,1]), ubound_intercept=as.numeric(ci[1,2]))
 
   return(ret)
 }

--- a/R/zyp.R
+++ b/R/zyp.R
@@ -13,7 +13,7 @@ zyp.sen <- function(formula, dataframe) {
   if (length(term) > 2) {
     stop("Only linear models are accepted")
   }
-  
+
   slopes <- unlist(lapply(1:(n-1), zyp.slopediff, x, y, n))
   sni <- which(is.finite(slopes))
   slope <- median(slopes[sni])
@@ -21,7 +21,7 @@ zyp.sen <- function(formula, dataframe) {
   intercept <- median(intercepts)
 
   res <- list(coefficients=c(intercept, slope), slopes = slopes, intercepts = intercepts, rank=2, residuals=(y - slope * x + intercept), x=x, y=y)
-  
+
   names(res$coefficients) = c("Intercept", term[2])
   class(res) = c("zyp", "lm")
   return(res)
@@ -40,9 +40,9 @@ confint.zyp <- function (object, parm, level = 0.95, ...) {
   n.prime <- length(slopes)
   isect.sd <- sqrt(var(intercepts))
   isect.mean <- mean(intercepts)
-  
+
   idx <- c(round((n.prime - c.alpha) / 2), round((n.prime + c.alpha) / 2))
-  
+
   rownames(res) <- names(object$coefficients)
   colnames(res) <- as.character(c((1 - level)/2, 1 - (1 - level)/2))
   res[2, ] <- slopes[idx]
@@ -60,10 +60,10 @@ zyp.zhang <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.
 
   ret <- c(lbound = NA, trend = NA, trendp = NA, ubound = NA,
            tau = NA, sig = NA, nruns = NA, autocor = NA, valid_frac = NA, linear = NA, intercept = NA)
-  
+
   # Prewhiten the original series
   c <- acf(data,lag.max=1,plot=FALSE,na.action=na.pass)$acf[2]
-  
+
   # Throw out data that is insufficient to compute the autocorrelation function
   if(is.na(c)) {
     return(ret)
@@ -77,10 +77,10 @@ zyp.zhang <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.
     yt <- t[1:(n-1)]
   }
 
-  dmap <- which(!is.na(y))        
+  dmap <- which(!is.na(y))
   ynm <- as.numeric(y[dmap])
   ytnm <- as.numeric(yt[dmap])
-  
+
   # Throw out crappy data
   if(length(dmap) <= 3 | length(which(ynm != 0)) < 3 | length(dmap) / n < 0.1) {
     return(ret)
@@ -89,7 +89,7 @@ zyp.zhang <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.
   # Calculate Slope
   sen <- zyp.sen(ynm~ytnm)
   trend <- sen$coefficients[2]
-        
+
   k <- 1
   c0 <- c
   if(c >= 0.05) {
@@ -102,7 +102,7 @@ zyp.zhang <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.
         break;
       }
       y <- (data[2:n] - c * data[1:(n-1)]) / (1 - c)
-            
+
       dmap <- which(!is.na(y))
       ynm <- as.numeric(y[dmap])
       ytnm <- as.numeric(yt[dmap])
@@ -110,30 +110,31 @@ zyp.zhang <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.
       trend <- sen$coefficients[2] # median(na.omit(sen$slopes))
 
       k <- k+1
-            
+
       tpdiff <- abs((trend - trend0) / trend)
       if(!is.na(tpdiff) && tpdiff <= 0.001 && abs(c-c0)<=0.0001){
         break
       }
-            
+
       trend0 <- trend
       c0 <- c
     }
   }
-          
+
   Kend <- Kendall(ytnm,ynm)
   tau <- Kend[1]
   Bsig <- Kend[2]
-  
+
   if(conf.intervals) {
     ci <- confint(sen)
   } else {
     ci <- matrix(rep(NA, 4), nrow=2, ncol=2)
   }
-  
+
   ret <- c(lbound = as.numeric(ci[2, 1]), trend=as.numeric(trend), trendp=(as.numeric(trend) * n), ubound = as.numeric(ci[2, 2]),
            tau=as.numeric(tau), sig=as.numeric(Bsig), nruns=as.numeric(k), autocor=as.numeric(c0), valid_frac=as.numeric(length(dmap)/length(y)),
-           linear=as.numeric(lm(data~t)$coefficients[2]), intercept=as.numeric(sen$coefficients[1]))
+           linear=as.numeric(lm(data~t)$coefficients[2]), lbound_intercept=as.numeric(ci[1,1]), intercept=as.numeric(sen$coefficients[1]),
+           ubound_intercept=as.numeric(ci[1,2]))
   return(ret)
 }
 
@@ -142,7 +143,7 @@ zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.f
 
   if(is.logical(x))
     stop("x cannot be of type 'logical' (perhaps you meant to specify conf.intervals?)")
-  
+
   n <- length(dat)
   t <- x
   t.prime <- t[1:(n-1)]
@@ -150,9 +151,9 @@ zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.f
 
   ret <- c(lbound = NA, trend=NA, trendp=NA, ubound = NA,
            tau=NA, sig=NA, nruns=NA, autocor=NA, valid_frac=NA, linear=NA, intercept=NA)
-  
- 
-  dmap <- which(!is.na(y))        
+
+
+  dmap <- which(!is.na(y))
   ynm <- as.numeric(y[dmap])
   tnm <- as.numeric(t[dmap])
 
@@ -166,10 +167,10 @@ zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.f
   trend <- sen$coefficients[2]
 
   # FIXME: ADD CHECK HERE FOR SMALL TREND
-  
+
   # Remove trend
   xt.prime <- dat[1:n] - trend * t
-  
+
   # Calculate AR(1)
   ac <- acf(xt.prime, lag.max=1, plot=FALSE, na.action=na.pass)$acf[2]
 
@@ -179,12 +180,12 @@ zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.f
   }
 
   yt.prime <- ifelse(rep(preserve.range.for.sig.test, n - 1), (xt.prime[2:n] - ac * xt.prime[1:(n-1)]) / (1 - ac), xt.prime[2:n] - ac * xt.prime[1:(n-1)])
-  
+
   ## Add the trend back into the residual
   yt <- yt.prime[1:(n-1)] + trend * t.prime
-  dmap.prime <- which(!is.na(yt))        
+  dmap.prime <- which(!is.na(yt))
   ytnm <- as.numeric(yt[dmap.prime])
-          
+
   # Calculate the Mann-Kendall test for significance on the blended series
   Kend <- Kendall(t.prime[dmap.prime],ytnm)
   tau <- Kend[1]
@@ -198,8 +199,9 @@ zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.f
 
   ret <- c(lbound = as.numeric(ci[2, 1]), trend=as.numeric(trend), trendp=as.numeric(trend) * n, ubound = as.numeric(ci[2, 2]),
            tau=as.numeric(tau), sig=as.numeric(Bsig), nruns=1, autocor=as.numeric(ac), valid_frac=as.numeric(length(dmap)/length(y)),
-           linear=as.numeric(lm(dat~t)$coefficients[2]), intercept=as.numeric(sen$coefficients[1]))
-           
+           linear=as.numeric(lm(dat~t)$coefficients[2]), lbound_intercept=as.numeric(ci[1,1]), intercept=as.numeric(sen$coefficients[1]),
+           ubound_intercept=as.numeric(ci[1,2]))
+
   return(ret)
 }
 
@@ -234,4 +236,4 @@ zyp.trend.csv <- function(filename, output.filename, metadata.cols, method=c("yu
   write.csv(zyp.trend.dataframe(indat, metadata.cols, method, conf.intervals, preserve.range.for.sig.test), output.filename, row.names=FALSE)
 }
 
-    
+

--- a/man/zyp.trend.csv.Rd
+++ b/man/zyp.trend.csv.Rd
@@ -18,7 +18,7 @@ zyp.trend.csv(filename, output.filename, metadata.cols,
 }
 \arguments{
   \item{indat}{the input data frame.}
-  
+
   \item{filename}{the filename of the input CSV file.}
 
   \item{output.filename}{the filename to write output to.}
@@ -44,7 +44,7 @@ zyp.trend.csv(filename, output.filename, metadata.cols,
   to have the same length of timeseries. NA values are handled
   correctly, so if you have several timeseries of unequal length you can
   pad them with NA values to provide valid input.
-  
+
   The prewhitened trend computation methods used are either Zhang's
   method (described in Wang and Swail, 2001) or Yue and Pilon's method
   (described in Yue and Pilon, 2002).
@@ -63,8 +63,10 @@ zyp.trend.csv(filename, output.filename, metadata.cols,
   \item{valid_frac}{the fraction of the data which is valid (not NA)
   once autocorrelation is removed.}
   \item{linear}{the least squares fit trend on the same dat.}
+  \item{lbound_intercept}{the lower bound of the estimate of the intercept of the Sen's slope (trend).}
   \item{intercept}{the intercept of the Sen's slope (trend).}
-  
+  \item{ubound_intercept}{the upper bound of the estimate of the intercept of the Sen's slope (trend).}
+
 }
 
 \seealso{

--- a/man/zyp.trend.csv.Rd
+++ b/man/zyp.trend.csv.Rd
@@ -63,8 +63,8 @@ zyp.trend.csv(filename, output.filename, metadata.cols,
   \item{valid_frac}{the fraction of the data which is valid (not NA)
   once autocorrelation is removed.}
   \item{linear}{the least squares fit trend on the same dat.}
-  \item{lbound_intercept}{the lower bound of the estimate of the intercept of the Sen's slope (trend).}
   \item{intercept}{the intercept of the Sen's slope (trend).}
+  \item{lbound_intercept}{the lower bound of the estimate of the intercept of the Sen's slope (trend).}
   \item{ubound_intercept}{the upper bound of the estimate of the intercept of the Sen's slope (trend).}
 
 }

--- a/man/zyp.trend.vector.Rd
+++ b/man/zyp.trend.vector.Rd
@@ -47,8 +47,8 @@ zyp.yuepilon(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=
   \item{valid_frac}{the fraction of the data which is valid (not NA)
   once autocorrelation is removed.}
   \item{linear}{the least squares fit trend on the same dat.}
-  \item{lbound_intercept}{the lower bound of the estimate of the intercept of the Sen's slope (trend).}
   \item{intercept}{the intercept of the Sen's slope (trend).}
+  \item{lbound_intercept}{the lower bound of the estimate of the intercept of the Sen's slope (trend).}
   \item{ubound_intercept}{the upper bound of the estimate of the intercept of the Sen's slope (trend).}
 
 }

--- a/man/zyp.trend.vector.Rd
+++ b/man/zyp.trend.vector.Rd
@@ -47,8 +47,10 @@ zyp.yuepilon(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=
   \item{valid_frac}{the fraction of the data which is valid (not NA)
   once autocorrelation is removed.}
   \item{linear}{the least squares fit trend on the same dat.}
+  \item{lbound_intercept}{the lower bound of the estimate of the intercept of the Sen's slope (trend).}
   \item{intercept}{the intercept of the Sen's slope (trend).}
-  
+  \item{ubound_intercept}{the upper bound of the estimate of the intercept of the Sen's slope (trend).}
+
 }
 
 \seealso{


### PR DESCRIPTION
Since `confint` calculates the upper and lower confidence limits for the estimate of the intercept of Sen's slope, I thought it would be handy for them to be returned in the results from `zyp.zhang` and `zyp.yuepilon`

Eg:

``` r
library(zyp)
dat <- c(1,3,2,5,7,9,5,10,12,15)
zyp.yuepilon(dat)
```

```
##           lbound            trend           trendp           ubound 
##      1.000000000      1.500000000     15.000000000      2.000000000 
##              tau              sig            nruns          autocor 
##      0.833333313      0.002498984      1.000000000     -0.091162344 
##       valid_frac           linear lbound_intercept        intercept 
##      1.000000000      1.400000000     -4.682899402     -0.750000000 
## ubound_intercept 
##      1.982899402
```
