### PR TITLE
modify default arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: zyp
-Version: 0.10-1
-Date: 2013-09-18
-Title: Zhang + Yue-Pilon trends package
+Version: 0.11
+Date: 2022-08-16
+Title: Zhang + Yue-Pilon Trends Package
 Author: David Bronaugh <bronaugh@uvic.ca>, Arelia Werner <wernera@uvic.ca> for the Pacific Climate Impacts Consortium
-Maintainer: David Bronaugh <bronaugh@uvic.ca>
+Maintainer: Lee Zeman <lzeman@uvic.ca>
 Depends: R (>= 2.4.0), Kendall
 Suggests: 
 Description: The zyp package contains an efficient implementation of Sen's slope method (Sen, 1968) plus implementation of Xuebin Zhang's (Zhang, 1999) and Yue-Pilon's (Yue, 2002) prewhitening approaches to determining trends in climate data.
 License: LGPL-2.1
-URL: http://www.r-project.org
+URL: https://www.r-project.org

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,9 @@ Package: zyp
 Version: 0.11
 Date: 2022-12-13
 Title: Zhang + Yue-Pilon Trends Package
-Author: David Bronaugh <bronaugh@uvic.ca>, Arelia Werner <wernera@uvic.ca> for the Pacific Climate Impacts Consortium
-Maintainer: Lee Zeman <lzeman@uvic.ca>
+Authors@R:c(person("David", "Bronaugh", email="bronaugh@uvic.ca", role="aut"), person("Arelia", "Schoeneberg", email="wernera@uvic.ca", role="aut"), person("Lee", "Zeman", email="lzeman@uvic.ca", role="cre"))
 Depends: R (>= 2.4.0), Kendall
 Suggests: 
-Description: The zyp package contains an efficient implementation of Sen's slope method (Sen, 1968) plus implementation of Xuebin Zhang's (Zhang, 2000) and Yue-Pilon's (Yue, 2002) prewhitening approaches to determining trends in climate data.
+Description: An efficient implementation of the slope method described by Sen (1968) <doi:10.1080/01621459.1968.10480934> plus implementation of prewhitening approaches to determining trends in climate data described by Zhang, Vincent, Hogg, and Niitsoo (2000) <doi:10.1080/07055900.2000.9649654> and Yue, Pilon, Phinney, and Cavadias (2002) <doi:10.1002/hyp.1095>.
 License: LGPL-2.1
 URL: https://www.r-project.org

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: zyp
 Version: 0.11
-Date: 2022-08-16
+Date: 2022-12-13
 Title: Zhang + Yue-Pilon Trends Package
 Author: David Bronaugh <bronaugh@uvic.ca>, Arelia Werner <wernera@uvic.ca> for the Pacific Climate Impacts Consortium
 Maintainer: Lee Zeman <lzeman@uvic.ca>
 Depends: R (>= 2.4.0), Kendall
 Suggests: 
-Description: The zyp package contains an efficient implementation of Sen's slope method (Sen, 1968) plus implementation of Xuebin Zhang's (Zhang, 1999) and Yue-Pilon's (Yue, 2002) prewhitening approaches to determining trends in climate data.
+Description: The zyp package contains an efficient implementation of Sen's slope method (Sen, 1968) plus implementation of Xuebin Zhang's (Zhang, 2000) and Yue-Pilon's (Yue, 2002) prewhitening approaches to determining trends in climate data.
 License: LGPL-2.1
 URL: https://www.r-project.org

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,8 @@
 export(zyp.sen)
 export(confint.zyp)
 export(zyp.trend.vector)
+export(zyp.trend.csv)
+export(zyp.trend.dataframe)
 export(zyp.zhang)
 export(zyp.yuepilon)
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,14 @@
+export(zyp.sen)
+export(confint.zyp)
+export(zyp.trend.vector)
+export(zyp.zhang)
+export(zyp.yuepilon)
+
+
 importFrom("stats", "acf", "confint", "lm", "median", "na.pass",
              "qnorm", "terms", "var")
 importFrom("utils", "read.csv", "write.csv")
 
 importFrom("Kendall", "Kendall")
+
+S3method("confint", "zyp")

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,0 +1,5 @@
+importFrom("stats", "acf", "confint", "lm", "median", "na.pass",
+             "qnorm", "terms", "var")
+importFrom("utils", "read.csv", "write.csv")
+
+importFrom("Kendall", "Kendall")

--- a/R/zyp.R
+++ b/R/zyp.R
@@ -50,7 +50,7 @@ confint.zyp <- function (object, parm, level = 0.95, ...) {
   return(res)
 }
 
-zyp.zhang <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=TRUE) {
+zyp.zhang <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
   data <- as.numeric(as.vector(y))
   if(is.logical(x))
     stop("x cannot be of type 'logical' (perhaps you meant to specify conf.intervals?)")
@@ -139,7 +139,7 @@ zyp.zhang <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.
   return(ret)
 }
 
-zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=TRUE) {
+zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
   dat <- as.numeric(as.vector(y))
 
   if(is.logical(x))
@@ -213,7 +213,7 @@ zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.f
 }
 
 # Applies either a Yue Pilon or Zhang trend calculation to a vector of data
-zyp.trend.vector <- function(y, x=1:length(y), method=c("yuepilon", "zhang"), conf.intervals=TRUE, preserve.range.for.sig.test=TRUE) {
+zyp.trend.vector <- function(y, x=1:length(y), method=c("yuepilon", "zhang"), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
   if(is.character(x))
     stop("x cannot be of type character (perhaps you meant to specify method?)")
 
@@ -224,7 +224,7 @@ zyp.trend.vector <- function(y, x=1:length(y), method=c("yuepilon", "zhang"), co
 }
 
 # Applies either a Yue Pilon or Zhang trend calculation to a data frame where there is one station per line with no metadata (and each year/month is a column of data)
-zyp.trend.dataframe <- function(indat, metadata.cols, method=c("yuepilon", "zhang"), conf.intervals=TRUE, preserve.range.for.sig.test=TRUE) {
+zyp.trend.dataframe <- function(indat, metadata.cols, method=c("yuepilon", "zhang"), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
   trend <- switch(match.arg(method),
            yuepilon = as.data.frame(t(apply(indat[, (1 + metadata.cols):ncol(indat)], 1, zyp.yuepilon, conf.intervals=conf.intervals, preserve.range.for.sig.test=preserve.range.for.sig.test))),
            zhang    = as.data.frame(t(apply(indat[, (1 + metadata.cols):ncol(indat)], 1, zyp.zhang, conf.intervals=conf.intervals, preserve.range.for.sig.test=preserve.range.for.sig.test))) )
@@ -238,7 +238,7 @@ zyp.trend.dataframe <- function(indat, metadata.cols, method=c("yuepilon", "zhan
 }
 
 # Applies either a Yue Pilon or Zhang trend calculation to a file in the format "metadata_1,...,metadata_n,year1,year2,...", where n is the number of metadata columns and the timeseries extending across the row
-zyp.trend.csv <- function(filename, output.filename, metadata.cols, method=c("yuepilon", "zhang"), conf.intervals=TRUE, csv.header=TRUE, preserve.range.for.sig.test=TRUE) {
+zyp.trend.csv <- function(filename, output.filename, metadata.cols, method=c("yuepilon", "zhang"), conf.intervals=TRUE, csv.header=TRUE, preserve.range.for.sig.test=FALSE) {
   indat <- read.csv(filename, csv.header)
   write.csv(zyp.trend.dataframe(indat, metadata.cols, method, conf.intervals, preserve.range.for.sig.test), output.filename, row.names=FALSE)
 }

--- a/R/zyp.R
+++ b/R/zyp.R
@@ -213,7 +213,7 @@ zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.f
 }
 
 # Applies either a Yue Pilon or Zhang trend calculation to a vector of data
-zyp.trend.vector <- function(y, x=1:length(y), method="zhang", conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
+zyp.trend.vector <- function(y, x=1:length(y), method=c("zhang", "yuepilon"), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
   if(is.character(x))
     stop("x cannot be of type character (perhaps you meant to specify method?)")
 
@@ -224,7 +224,7 @@ zyp.trend.vector <- function(y, x=1:length(y), method="zhang", conf.intervals=TR
 }
 
 # Applies either a Yue Pilon or Zhang trend calculation to a data frame where there is one station per line with no metadata (and each year/month is a column of data)
-zyp.trend.dataframe <- function(indat, metadata.cols, method="zhang", conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
+zyp.trend.dataframe <- function(indat, metadata.cols, method=c("zhang", "yuepilon"), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
   trend <- switch(match.arg(method),
            zhang    = as.data.frame(t(apply(indat[, (1 + metadata.cols):ncol(indat)], 1, zyp.zhang, conf.intervals=conf.intervals, preserve.range.for.sig.test=preserve.range.for.sig.test))),
            yuepilon = as.data.frame(t(apply(indat[, (1 + metadata.cols):ncol(indat)], 1, zyp.yuepilon, conf.intervals=conf.intervals, preserve.range.for.sig.test=preserve.range.for.sig.test))) )
@@ -238,7 +238,7 @@ zyp.trend.dataframe <- function(indat, metadata.cols, method="zhang", conf.inter
 }
 
 # Applies either a Yue Pilon or Zhang trend calculation to a file in the format "metadata_1,...,metadata_n,year1,year2,...", where n is the number of metadata columns and the timeseries extending across the row
-zyp.trend.csv <- function(filename, output.filename, metadata.cols, method="zhang", conf.intervals=TRUE, csv.header=TRUE, preserve.range.for.sig.test=FALSE) {
+zyp.trend.csv <- function(filename, output.filename, metadata.cols, method=c("zhang", "yuepilon"), conf.intervals=TRUE, csv.header=TRUE, preserve.range.for.sig.test=FALSE) {
   indat <- read.csv(filename, csv.header)
   write.csv(zyp.trend.dataframe(indat, metadata.cols, method, conf.intervals, preserve.range.for.sig.test), output.filename, row.names=FALSE)
 }

--- a/R/zyp.R
+++ b/R/zyp.R
@@ -213,21 +213,21 @@ zyp.yuepilon <- function(y, x=1:length(y), conf.intervals=TRUE, preserve.range.f
 }
 
 # Applies either a Yue Pilon or Zhang trend calculation to a vector of data
-zyp.trend.vector <- function(y, x=1:length(y), method=c("yuepilon", "zhang"), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
+zyp.trend.vector <- function(y, x=1:length(y), method="zhang", conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
   if(is.character(x))
     stop("x cannot be of type character (perhaps you meant to specify method?)")
 
   switch(match.arg(method),
-         yuepilon = zyp.yuepilon(y, x, conf.intervals, preserve.range.for.sig.test),
-         zhang    = zyp.zhang(y, x, conf.intervals, preserve.range.for.sig.test)
+         zhang    = zyp.zhang(y, x, conf.intervals, preserve.range.for.sig.test),
+         yuepilon = zyp.yuepilon(y, x, conf.intervals, preserve.range.for.sig.test)
          )
 }
 
 # Applies either a Yue Pilon or Zhang trend calculation to a data frame where there is one station per line with no metadata (and each year/month is a column of data)
-zyp.trend.dataframe <- function(indat, metadata.cols, method=c("yuepilon", "zhang"), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
+zyp.trend.dataframe <- function(indat, metadata.cols, method="zhang", conf.intervals=TRUE, preserve.range.for.sig.test=FALSE) {
   trend <- switch(match.arg(method),
-           yuepilon = as.data.frame(t(apply(indat[, (1 + metadata.cols):ncol(indat)], 1, zyp.yuepilon, conf.intervals=conf.intervals, preserve.range.for.sig.test=preserve.range.for.sig.test))),
-           zhang    = as.data.frame(t(apply(indat[, (1 + metadata.cols):ncol(indat)], 1, zyp.zhang, conf.intervals=conf.intervals, preserve.range.for.sig.test=preserve.range.for.sig.test))) )
+           zhang    = as.data.frame(t(apply(indat[, (1 + metadata.cols):ncol(indat)], 1, zyp.zhang, conf.intervals=conf.intervals, preserve.range.for.sig.test=preserve.range.for.sig.test))),
+           yuepilon = as.data.frame(t(apply(indat[, (1 + metadata.cols):ncol(indat)], 1, zyp.yuepilon, conf.intervals=conf.intervals, preserve.range.for.sig.test=preserve.range.for.sig.test))) )
 
   if(metadata.cols > 0) {
     trend <- cbind(indat[,1:metadata.cols], trend)
@@ -238,7 +238,7 @@ zyp.trend.dataframe <- function(indat, metadata.cols, method=c("yuepilon", "zhan
 }
 
 # Applies either a Yue Pilon or Zhang trend calculation to a file in the format "metadata_1,...,metadata_n,year1,year2,...", where n is the number of metadata columns and the timeseries extending across the row
-zyp.trend.csv <- function(filename, output.filename, metadata.cols, method=c("yuepilon", "zhang"), conf.intervals=TRUE, csv.header=TRUE, preserve.range.for.sig.test=FALSE) {
+zyp.trend.csv <- function(filename, output.filename, metadata.cols, method="zhang", conf.intervals=TRUE, csv.header=TRUE, preserve.range.for.sig.test=FALSE) {
   indat <- read.csv(filename, csv.header)
   write.csv(zyp.trend.dataframe(indat, metadata.cols, method, conf.intervals, preserve.range.for.sig.test), output.filename, row.names=FALSE)
 }

--- a/man/zyp.Rd
+++ b/man/zyp.Rd
@@ -4,6 +4,18 @@
 \docType{package}
 \title{ZYP Prewhitened Nonlinear Trend Analysis Package}
 \description{
+Update April 1 2022
+
+  At the time of writing, the application of the Yue Pilon (Yue et al. 2002) is actively discouraged in the
+hydrologic community. This is because the trend free whitening procedure (TFWP) applied in the Yue Pilon
+method shows very high Type-I error rates with increasing autocorrelation and hence the rate of false trend
+detection with this method is unacceptable (Buerger 2017; Zhang and Zwiers 2004). This version of zyp has
+been modified to apply Zhang et al. 2000 trend detection methods as default.
+
+Additionally, preserve.range.for.sig.test is set to TRUE throughout to make sure significance is reinflated
+as per the Yue and Pilon paper exactly.
+
+
   This function includes two approaches to analyze for trend, the Zhang method and Yue and Pilon method. 
 These differ in their approach to pre-whitening to removing lag-1 autocorrelation. The magnitude of the
 trend is computed using the Theil-Sen approach (TSA).
@@ -28,17 +40,34 @@ controlled using the parameter 'preserve.range.for.sig.test'; setting
 this to 'FALSE' should give results which follow the Yue and Pilon paper exactly.
 }
 \references{
+\cite{Buerger, G., 2017. On trend detection. Hydrological Processes 31,
+  4039-4042. https://doi.org/10.1002/hyp.11280 }
+  
 \cite{Wang, X.L. and Swail, V.R., 2001. Changes in extreme wave heights
   in northern hemisphere oceans and related atmospheric circulation
-  regimes. Journal of Climate, 14: 2204-2221. }
-
+  regimes. Journal of Climate, 14: 2204-2221. 
+  https://doi.org/10.1175/1520-0442(2001)014%3c2204:COEWHI%3e2.0.CO;2 }
+  
 \cite{Yue, S., P. Pilon, B. Phinney and G. Cavadias, 2002. The influence
   of autocorrelation on the ability to detect trend in hydrological
-  series. Hydrological Processes, 16: 1807-1829.}
-
+  series. Hydrological Processes, 16: 1807-1829.
+  https://doi.org/10.1002/hyp.1095 }
+  
 \cite{Zhang, X., Vincent, L.A., Hogg, W.D. and Niitsoo, A.,
   2000. Temperature and Precipitation Trends in Canada during the
-  20th Century. Atmosphere-Ocean 38(3): 395-429.}
+  20th Century. Atmosphere-Ocean 38(3): 395-429.
+  https://doi.org/10.1080/07055900.2000.9649654 }
+  
+\cite{Zhang, X., Zwiers, F.W., 2004. Comment on "Applicability of
+  prewhitening to eliminate the influence of serial correlation on the
+  Mann-Kendall test" by Sheng Yue and Chun Yuan Wang. Water Resources 
+  Research 40. https://doi.org/10.1029/2003WR002073 }
+
+
+
+
+
+
 
 \cite{Sen, P.K., 1968. Estimates of the Regression Coefficient Based on
   Kendall's Tau. Journal of the American Statistical Association

--- a/man/zyp.Rd
+++ b/man/zyp.Rd
@@ -40,39 +40,28 @@ controlled using the parameter 'preserve.range.for.sig.test'; setting
 this to 'FALSE' should give results which follow the Yue and Pilon paper exactly.
 }
 \references{
+
 \cite{Buerger, G., 2017. On trend detection. Hydrological Processes 31,
-  4039-4042. https://doi.org/10.1002/hyp.11280 }
+  4039-4042. }
   
 \cite{Wang, X.L. and Swail, V.R., 2001. Changes in extreme wave heights
   in northern hemisphere oceans and related atmospheric circulation
-  regimes. Journal of Climate, 14: 2204-2221. 
-  https://doi.org/10.1175/1520-0442(2001)014%3c2204:COEWHI%3e2.0.CO;2 }
+  regimes. Journal of Climate, 14: 2204-2221. }
   
 \cite{Yue, S., P. Pilon, B. Phinney and G. Cavadias, 2002. The influence
   of autocorrelation on the ability to detect trend in hydrological
-  series. Hydrological Processes, 16: 1807-1829.
-  https://doi.org/10.1002/hyp.1095 }
+  series. Hydrological Processes, 16: 1807-1829. }
   
 \cite{Zhang, X., Vincent, L.A., Hogg, W.D. and Niitsoo, A.,
   2000. Temperature and Precipitation Trends in Canada during the
-  20th Century. Atmosphere-Ocean 38(3): 395-429.
-  https://doi.org/10.1080/07055900.2000.9649654 }
+  20th Century. Atmosphere-Ocean 38(3): 395-429. }
   
 \cite{Zhang, X., Zwiers, F.W., 2004. Comment on "Applicability of
   prewhitening to eliminate the influence of serial correlation on the
   Mann-Kendall test" by Sheng Yue and Chun Yuan Wang. Water Resources 
-  Research 40. https://doi.org/10.1029/2003WR002073 }
-
-
-
-
-
-
-
-\cite{Sen, P.K., 1968. Estimates of the Regression Coefficient Based on
-  Kendall's Tau. Journal of the American Statistical Association
-  Vol. 63, No. 324: 1379-1389.}
+  Research 40. }
 }
+
 \seealso{
 \code{\link{zyp.trend.csv}}, \code{\link{zyp.trend.vector}}.
 }

--- a/man/zyp.trend.csv.Rd
+++ b/man/zyp.trend.csv.Rd
@@ -70,11 +70,13 @@ zyp.trend.csv(filename, output.filename, metadata.cols,
 }
 
 \seealso{
-\code{\link{zyp.trend.vector}}, \link{zyp-package}.
+\code{\link{zyp.trend.vector}}.
 }
 \examples{
-#zyp.trend.csv("in.csv", "out.csv", 2, "yuepilon", F)
-#trends <- zyp.trend.dataframe(indat, 2, "yuepilon")
+\dontrun{
+zyp.trend.csv("in.csv", "out.csv", 2, "yuepilon", F)
+trends <- zyp.trend.dataframe(indat, 2, "yuepilon")
+}
 }
 \keyword{ts}
 \keyword{robust}

--- a/man/zyp.trend.csv.Rd
+++ b/man/zyp.trend.csv.Rd
@@ -10,10 +10,10 @@
   nonlinear prewhitened trends.
 }
 \usage{
-zyp.trend.dataframe(indat, metadata.cols, method="zhang",
+zyp.trend.dataframe(indat, metadata.cols, method=c("zhang", "yuepilon"),
                     conf.intervals=TRUE, preserve.range.for.sig.test=FALSE)
 zyp.trend.csv(filename, output.filename, metadata.cols,
-              method="zhang", conf.intervals=TRUE,
+              method=c("zhang", "yuepilon"), conf.intervals=TRUE,
               csv.header=TRUE, preserve.range.for.sig.test=FALSE)
 }
 \arguments{

--- a/man/zyp.trend.csv.Rd
+++ b/man/zyp.trend.csv.Rd
@@ -10,11 +10,11 @@
   nonlinear prewhitened trends.
 }
 \usage{
-zyp.trend.dataframe(indat, metadata.cols, method=c("yuepilon", "zhang"),
-                    conf.intervals=TRUE, preserve.range.for.sig.test=TRUE)
+zyp.trend.dataframe(indat, metadata.cols, method="zhang",
+                    conf.intervals=TRUE, preserve.range.for.sig.test=FALSE)
 zyp.trend.csv(filename, output.filename, metadata.cols,
-              method=c("yuepilon", "zhang"), conf.intervals=TRUE,
-              csv.header=TRUE, preserve.range.for.sig.test=TRUE)
+              method="zhang", conf.intervals=TRUE,
+              csv.header=TRUE, preserve.range.for.sig.test=FALSE)
 }
 \arguments{
   \item{indat}{the input data frame.}

--- a/man/zyp.trend.vector.Rd
+++ b/man/zyp.trend.vector.Rd
@@ -9,10 +9,10 @@
   method of computing nonlinear prewhitened trends.
 }
 \usage{
-zyp.trend.vector(y, x=1:length(y), method=c("yuepilon", "zhang"),
-conf.intervals=TRUE, preserve.range.for.sig.test=TRUE)
-zyp.zhang(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=TRUE)
-zyp.yuepilon(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=TRUE)
+zyp.trend.vector(y, x=1:length(y), method="zhang",
+conf.intervals=TRUE, preserve.range.for.sig.test=FALSE)
+zyp.zhang(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE)
+zyp.yuepilon(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE)
 }
 \arguments{
   \item{y}{vector of input data.}

--- a/man/zyp.trend.vector.Rd
+++ b/man/zyp.trend.vector.Rd
@@ -9,7 +9,7 @@
   method of computing nonlinear prewhitened trends.
 }
 \usage{
-zyp.trend.vector(y, x=1:length(y), method="zhang",
+zyp.trend.vector(y, x=1:length(y), method=c("zhang", "yuepilon"),
 conf.intervals=TRUE, preserve.range.for.sig.test=FALSE)
 zyp.zhang(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE)
 zyp.yuepilon(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=FALSE)
@@ -58,10 +58,10 @@ zyp.yuepilon(y, x=1:length(y), conf.intervals=TRUE, preserve.range.for.sig.test=
 }
 \examples{
 # Without confidence intervals, using the wrapper routine
-d <- zyp.trend.vector(c(0, 1, 3, 4, 2, 5), method="yuepilon", conf.intervals=FALSE)
+d <- zyp.trend.vector(c(0, 1, 3, 4, 2, 5), conf.intervals=FALSE)
 
 # With confidence intervals, using the wrapper routine
-d <- zyp.trend.vector(c(0, 1, 3, 4, 2, 5), method="yuepilon")
+d <- zyp.trend.vector(c(0, 1, 3, 4, 2, 5))
 
 # With confidence intervals, not using the wrapper routine
 d.zhang <- zyp.zhang(c(0, 1, 3, 4, 2, 5))

--- a/man/zyp.trend.vector.Rd
+++ b/man/zyp.trend.vector.Rd
@@ -4,7 +4,7 @@
 \alias{zyp.yuepilon}
 \title{zyp.trend.vector}
 \description{
-  Computes a prewhitened linear trend on a vector of data. The zyp
+  Computes a prewhitened linear trend on a vector of data. The 'zyp'
   package  allows you to use either Zhang's method, or the Yue Pilon
   method of computing nonlinear prewhitened trends.
 }


### PR DESCRIPTION
Makes the Zhang method the default, [updates documentation](https://github.com/pacificclimate/zyp/pull/7#pullrequestreview-929444143), and brings documentation into line with CRAN standards, which had shifted somewhat in the nine years since this package was last submitted. 

This branch has been [accepted](https://cran.r-project.org/web/packages/zyp/index.html) by CRAN as version 0.11.

Resolves #6 