### PR TITLE
update changelog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Changes from version 0.11 to 0.11-1
+	* Updated changelog, which was forgotten in last update
+Changes from version 0.10-1 to 0.11
+        * Changed default method from Yue-Pilon to Zhang
+	* Changed default value for preserve.range.for.dig.test from TRUE to FALSE
 Changes from version 0.9-3 to 0.10-1:
 	* CHECK YOUR CODE. This version may cause code which does not use named parameters for conf.intervals and method for zyp.trend.vector, zyp.trend.yuepilon, and zyp.trend.zhang to fail. Naming the parameters will make the code work again.
 	* Added options to zyp.trend.vector to allow the user to supply time data instead of assuming even spacing.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: zyp
-Version: 0.11
-Date: 2022-12-13
+Version: 0.11-1
+Date: 2023-03-22
 Title: Zhang + Yue-Pilon Trends Package
 Authors@R:c(person("David", "Bronaugh", email="bronaugh@uvic.ca", role="aut"), person("Arelia", "Schoeneberg", email="wernera@uvic.ca", role="aut"), person("Lee", "Zeman", email="lzeman@uvic.ca", role="cre"))
 Depends: R (>= 2.4.0), Kendall


### PR DESCRIPTION
This PR updates the changelog, which was forgotten for version 0.11. The lack of changelog updates may have confused a visitor to github, who reported that the package had not been updated when it had been. 

I've put in an entry for version 0.11-1, so I can upload the new ChangeLog to CRAN.

Resolves #9 